### PR TITLE
Update to the parameters output PR

### DIFF
--- a/src/aiida_vasp/parsers/neb.py
+++ b/src/aiida_vasp/parsers/neb.py
@@ -4,18 +4,6 @@ from aiida_vasp.parsers.content_parsers import *
 
 from .vasp import MissingFileError, NotificationComposer, QuantityMissingError, VaspParser, get_structure_node
 
-DEFAULT_QUANTITIES = (
-    'total_energies',
-    'maximum_stress',
-    'maximum_force',
-    'notifications',
-    'run_status',
-    'run_stats',
-    'version',
-    'band_properties',
-)
-
-
 DEFAULT_EXCLUDED_QUANTITIES = (
     'energies',
     'chgcar',

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -344,14 +344,6 @@ class VaspParser(Parser):
             error = self._check_vasp_errors(self.parser_notifications)
             return error
 
-    # def _compose_parameters(self, quantities_each):
-    #     """
-    #     Compose the `parameters` output node.
-    #     """
-    #     out_dict = {}
-    #     gather_quantities(quantities_each, self.user_config.file_mapping['vasprun.xml'], out_dict, ('parameters'))
-    #     return orm.Dict(dict=out_dict)
-
     def _compose_misc(self, quantities_each):
         """Compose the `misc` output node"""
 

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -52,17 +52,6 @@ class MissingFileError(ParserError):
     pass
 
 
-DEFAULT_QUANTITIES = (
-    'total_energies',
-    'maximum_stress',
-    'maximum_force',
-    'notifications',
-    'run_status',
-    'run_stats',
-    'version',
-    'band_properties',
-)
-
 DEFAULT_EXCLUDED_QUANTITIES = (
     'energies',
     'chgcar',
@@ -72,6 +61,7 @@ DEFAULT_EXCLUDED_QUANTITIES = (
     'magnetization_density',
     'elastic_moduli',
     'symmetries',
+    'parameters',  # The parameters used for the calculation
 )
 
 DEFAULT_EXCLUDED_NODE = tuple(['bands', 'dos', 'kpoints', 'trajectory'])
@@ -103,6 +93,7 @@ MISC_QUANTITIES = (
     'fermi_level',
     'band_properties',
     'magnetization',
+    'parameters',
 )
 
 # Miscellaneous quantities that should be collected into an `arrays`` node
@@ -353,13 +344,13 @@ class VaspParser(Parser):
             error = self._check_vasp_errors(self.parser_notifications)
             return error
 
-    def _compose_parameters(self, quantities_each):
-        """
-        Compose the `parameters` output node.
-        """
-        out_dict = {}
-        gather_quantities(quantities_each, self.user_config.file_mapping['vasprun.xml'], out_dict, ('parameters'))
-        return orm.Dict(dict=out_dict)
+    # def _compose_parameters(self, quantities_each):
+    #     """
+    #     Compose the `parameters` output node.
+    #     """
+    #     out_dict = {}
+    #     gather_quantities(quantities_each, self.user_config.file_mapping['vasprun.xml'], out_dict, ('parameters'))
+    #     return orm.Dict(dict=out_dict)
 
     def _compose_misc(self, quantities_each):
         """Compose the `misc` output node"""

--- a/tests/parsers/test_new_parser.py
+++ b/tests/parsers/test_new_parser.py
@@ -22,6 +22,14 @@ def test_parser_bare(calc_with_retrieved, request):
     assert 'arrays' in parser.outputs
     assert 'dielectrics`' not in parser.outputs
     assert 'born_charges' not in parser.outputs
+    assert 'parameters' not in parser.outputs['misc']
+
+    # Test the parameters outputs
+    node = calc_with_retrieved(file_path, {'parser_settings': {'include_quantity': ['parameters']}})
+    parser = VaspParser(node)
+    parser.parse(retrieved_tempoary_folder=file_path)
+    assert 'parameters' in parser.outputs['misc']
+    assert 'system' in parser.outputs['misc']['parameters']
 
 
 @pytest.fixture


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Hello I just did a minor update to move the parameters output to the `misc` node and make it default to false. We kind of try to limit the number of nodes each calculation produce. Is it OK for your use case?

To turn on recording of the exact parameters used, set `builder.settings['paraser_settings']['include_quantitity'] = ['parameters']` 